### PR TITLE
batch reveal non-breaking impl

### DIFF
--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -560,7 +560,7 @@ class WalletClient extends Client {
     return this.post(`/wallet/${id}/reveal`, options);
   }
 
-   /**
+  /**
    * Create batched reveal transaction.
    * @param {String} id
    * @param {Object} options
@@ -569,6 +569,17 @@ class WalletClient extends Client {
 
   createBatchReveal(id, options) {
     return this.post(`/wallet/${id}/batch/reveal`, options);
+  }
+
+  /**
+   * Create batched reveal transaction.
+   * @param {String} id
+   * @param {Object} options
+   * @returns {Promise}
+   */
+
+  createBatchRevealWithCache(id, options) {
+    return this.post(`/wallet/${id}/batch/revealwithcache`, options);
   }
 
   /**
@@ -1322,6 +1333,17 @@ class Wallet extends EventEmitter {
 
   createBatchReveal(id, options) {
     return this.client.createBatchReveal(this.id, options);
+  }
+
+  /**
+   * Create batched reveal with cache transaction.
+   * @param {String} id
+   * @param {Object} options
+   * @returns {Promise}
+   */
+
+  createBatchRevealWithCache(id, options) {
+    return this.client.createBatchRevealWithCache(this.id, options);
   }
 
   /**


### PR DESCRIPTION
This PR contains a new endpoint revealwithcache to prevent breaking of old clients while rolling out the batchreveal change