### PR TITLE
added a new command restore to restore wallet from a backup file

### DIFF
--- a/bin/hsw-cli
+++ b/bin/hsw-cli
@@ -481,6 +481,27 @@ class CLI {
     this.log(result);
   }
 
+  async restore() {
+
+    if (this.argv.length != 1) {
+      console.log("Please provide backup file path")
+    }
+
+    const path = require('path');
+    const fs = require("fs");
+
+    const filePath = this.argv[0];    
+    const resolvedPath = path.resolve(filePath);
+
+    
+    if (!fs.existsSync(resolvedPath)) {
+      this.log('Provided backup file does not exists ...');
+      return;
+    }    
+    
+    await this.client.post('/walletrestorefromfile', {filePath});
+  }
+
   async handleWallet() {
     switch (this.argv.shift()) {
       case 'listen':
@@ -594,6 +615,9 @@ class CLI {
       case 'rescan':
         await this.rescan();
         break;
+      case 'restore':
+        await this.restore();
+        break;
       default:
         this.log('Unrecognized command.');
         this.log('Commands:');
@@ -628,6 +652,7 @@ class CLI {
         this.log('  $ unlock [passphrase] [timeout?]: Unlock wallet.');
         this.log('  $ resend: Resend pending transactions.');
         this.log('  $ rescan [height]: Rescan for transactions.');
+        this.log('  $ restore [backup]: Restore wallet(s) from backup.');
         this.log('Other Options:');
         this.log('  --passphrase [passphrase]: For signing/account-creation.');
         this.log('  --account [account-name]: Account name.');

--- a/bin/hsw-cli
+++ b/bin/hsw-cli
@@ -4,6 +4,8 @@
 
 const Config = require('bcfg');
 const WalletClient = require('../lib/wallet');
+const path = require('path');
+const fs = require("fs");
 const EXP = 6;
 
 const ports = {
@@ -485,10 +487,7 @@ class CLI {
 
     if (this.argv.length != 1) {
       console.log("Please provide backup file path")
-    }
-
-    const path = require('path');
-    const fs = require("fs");
+    }    
 
     const filePath = this.argv[0];    
     const resolvedPath = path.resolve(filePath);


### PR DESCRIPTION
PR contains a new command that uploads a wallet backup file to hsd-wallet. hsw-cli and hsd-wallet needs to be on the same node. Since hsw-cli only passes the filepath. And hsd-wallet assumes file is locally reachable and loads it.

Basic usage of the new command:

**hsw-cli restore /home/rozaydin/backup_file.zip**

if no error occurs commands return nothing, if an error occurs it returns the error.

Features tests contain a step to test this functionality

Signed-off-by: rozaydin <ridvan@namebase.io>