### PR TITLE
Ridvan batch renewal

### DIFF
--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -1356,6 +1356,16 @@ class Wallet extends EventEmitter {
   }
 
   /**
+   * Create batched renew transaction.
+   * @param {Object} options
+   * @returns {Promise}
+   */
+
+  createBatchRenew(options) {
+    return this.client.createBatchRenew(this.id, options);
+  }
+
+  /**
    * Create renewal transaction.
    * @param {Object} options
    * @returns {Promise}

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -605,6 +605,17 @@ class WalletClient extends Client {
   }
 
   /**
+   * Create batched renew transaction.
+   * @param {String} id
+   * @param {Object} options
+   * @returns {Promise}
+   */
+
+  createBatchRenew(id, options) {
+    return this.post(`/wallet/${id}/batch/renew`, options);
+  }
+
+  /**
    * Create renewal transaction.
    * @param {String} id
    * @param {Object} options


### PR DESCRIPTION
Contains **hs-client** modifications for batch renew call. 
Underneath hs-client makes a http call to new **batch-renew** endpoint.
- batch-renew endpoint is implemented on the namebase hsd plugin, thus this client call can only be used with namebase-full-node